### PR TITLE
NDRS-381 changes plus other minor edits

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -32,15 +32,15 @@ Compiles casper client software using `cargo`.
 
 List previously created network assets.
 
-### nctl-assets-setup net={X:-1} nodes={Y:-5} users={Z:-5}
+### nctl-assets-setup net={W:-1} nodes={X:-5} users={Y:-5} bootstraps={Z:-1}
 
 Sets up assets required to run a local N-node network - this includes binaries, chainspec, config, faucet, keys ... etc.
 
 e.g. `nctl-assets-setup`
 
-e.g. `nctl-assets-setup net=1 nodes=5 users=5`  (same as above)
+e.g. `nctl-assets-setup net=1 nodes=5 users=5 bootstraps=1`  (same as above)
 
-e.g. `nctl-assets-setup net=2 nodes=10 users=10`
+e.g. `nctl-assets-setup net=2 nodes=10 users=10 bootstraps=4`
 
 NOTE: default
 

--- a/sh/assets/setup.sh
+++ b/sh/assets/setup.sh
@@ -129,7 +129,7 @@ function _set_faucet() {
 #   Path to network directory.
 #   Network ordinal identifer.
 #   Count of nodes to setup.
-#   Count of boostraps to setup.
+#   Count of bootstraps to setup.
 #######################################
 function _set_nodes() {
     log "... nodes"
@@ -147,7 +147,7 @@ function _set_nodes() {
 #   Path to network directory.
 #   Network ordinal identifer.
 #   Node ordinal identifer.
-#   Count of boostraps to setup.
+#   Count of bootstraps to setup.
 #######################################
 function _set_node ()
 {
@@ -164,12 +164,12 @@ function _set_node ()
     # Set config params.
     HTTP_SERVER_BIND_PORT=$((50000 + ($2 * 100) + $node_id))
     NETWORK_BIND_PORT=0
-    if [ $3 -eq 1 ]; then
-        NETWORK_BIND_PORT=34553
+    if [ $3 -le $4 ]; then
+        NETWORK_BIND_PORT=$((34452 + ($2 * 100) + $node_id))
         NETWORK_KNOWN_ADDRESSES=""
     else
         NETWORK_BIND_PORT=0
-        NETWORK_KNOWN_ADDRESSES="'127.0.0.1:34553'"
+        NETWORK_KNOWN_ADDRESSES="$(get_bootstrap_known_addresses $2 $4)"
     fi
 
     # Set config.
@@ -185,6 +185,37 @@ function _set_node ()
         $1/nodes/node-$3/keys/public_key_hex \
         100000000000000000 \
         $((100000000000000 * $3))
+}
+
+#######################################
+# Get network known addresses - i.e. those of bootstrap nodes.
+# Arguments:
+#   Network ordinal identifer.
+#   Count of bootstraps to setup.
+#######################################
+function get_bootstrap_known_addresses() {
+    result=""
+
+    for bootstrap_idx in $(seq 1 $2)
+    do
+        address=$(get_bootstrap_known_address $1 $bootstrap_idx)
+        result=$result"'"$address"',"
+    done
+
+    echo $result
+}
+
+#######################################
+# Get a network known addresses - i.e. those of bootstrap nodes.
+# Arguments:
+#   Network ordinal identifer.
+#   Node ordinal identifer.
+#######################################
+function get_bootstrap_known_address() {
+    port=$((34452 + ($1 * 100) + $2))
+    address="127.0.0.1:"$port
+
+    echo $address
 }
 
 #######################################
@@ -219,7 +250,7 @@ function _set_user() {
 #   Path to network directory.
 #   Network ordinal identifer.
 #   Count of nodes to setup.
-#   Count of boostraps to setup.
+#   Count of bootstraps to setup.
 #   Count of users to setup.
 #######################################
 function _set_vars() {
@@ -246,7 +277,7 @@ export NCTL_NET_USER_COUNT=$5
 # Arguments:
 #   Network ordinal identifer.
 #   Count of nodes to setup.
-#   Count of boostraps to setup.
+#   Count of bootstraps to setup.
 #   Count of users to setup.
 #######################################
 function _main() {
@@ -322,7 +353,7 @@ users=${users:-5}
 
 # Execute when inputs are valid.
 if [ $bootstraps -ge $nodes ]; then
-    log_error "Invalid input: boostraps MUST BE < nodes"
+    log_error "Invalid input: bootstraps MUST BE < nodes"
 else
     _main $net $nodes $bootstraps $users
 fi

--- a/sh/assets/setup.sh
+++ b/sh/assets/setup.sh
@@ -83,8 +83,8 @@ function _set_chainspec_account() {
 #   NCTL - path to nctl home directory.
 # Arguments:
 #   Path to network directory.
-#   Nodeset count.
 #   Network ordinal identifer.
+#   Nodeset count.
 #######################################
 function _set_daemon() {
     log "... daemon"
@@ -127,16 +127,17 @@ function _set_faucet() {
 # Sets assets pertaining to all nodes within network.
 # Arguments:
 #   Path to network directory.
-#   Count of nodes to setup.
 #   Network ordinal identifer.
+#   Count of nodes to setup.
+#   Count of boostraps to setup.
 #######################################
 function _set_nodes() {
     log "... nodes"
 
     mkdir $1/nodes
-    for node_id in $(seq 1 $2)
+    for node_id in $(seq 1 $3)
     do
-        _set_node $1 $node_id $3
+        _set_node $1 $2 $node_id $4
     done
 }
 
@@ -144,25 +145,26 @@ function _set_nodes() {
 # Sets assets pertaining to a single node.
 # Arguments:
 #   Path to network directory.
-#   Node ordinal identifer.
 #   Network ordinal identifer.
+#   Node ordinal identifer.
+#   Count of boostraps to setup.
 #######################################
 function _set_node ()
 {
     # Set directory.
-    mkdir $1/nodes/node-$2
-    mkdir $1/nodes/node-$2/config
-    mkdir $1/nodes/node-$2/keys
-    mkdir $1/nodes/node-$2/logs
-    mkdir $1/nodes/node-$2/storage
+    mkdir $1/nodes/node-$3
+    mkdir $1/nodes/node-$3/config
+    mkdir $1/nodes/node-$3/keys
+    mkdir $1/nodes/node-$3/logs
+    mkdir $1/nodes/node-$3/storage
 
     # Set keys.
-    $1/bin/casper-client keygen -f $1/nodes/node-$2/keys > /dev/null 2>&1
+    $1/bin/casper-client keygen -f $1/nodes/node-$3/keys > /dev/null 2>&1
 
     # Set config params.
-    HTTP_SERVER_BIND_PORT=$((50000 + ($3 * 100) + $node_id))
+    HTTP_SERVER_BIND_PORT=$((50000 + ($2 * 100) + $node_id))
     NETWORK_BIND_PORT=0
-    if [ $2 = "1" ]; then
+    if [ $3 -eq 1 ]; then
         NETWORK_BIND_PORT=34553
         NETWORK_KNOWN_ADDRESSES=""
     else
@@ -171,7 +173,7 @@ function _set_node ()
     fi
 
     # Set config.
-    path_config=$1/nodes/node-$2/config/node-config.toml
+    path_config=$1/nodes/node-$3/config/node-config.toml
     cp $NCTL/templates/node-config.toml $path_config
     sed -i "s/{NETWORK_BIND_PORT}/$NETWORK_BIND_PORT/g" $path_config > /dev/null 2>&1
     sed -i "s/{NETWORK_KNOWN_ADDRESSES}/$NETWORK_KNOWN_ADDRESSES/g" $path_config > /dev/null 2>&1
@@ -180,9 +182,9 @@ function _set_node ()
     # Set chainspec account.
     _set_chainspec_account \
         $1 \
-        $1/nodes/node-$2/keys/public_key_hex \
+        $1/nodes/node-$3/keys/public_key_hex \
         100000000000000000 \
-        $((100000000000000 * $2))
+        $((100000000000000 * $3))
 }
 
 #######################################
@@ -265,9 +267,9 @@ function _main() {
     log "setting network artefacts:"
     _set_bin $net_path
     _set_chainspec $net_path $1
-    _set_daemon $net_path $2 $1
+    _set_daemon $net_path $1 $2
     _set_faucet $net_path
-    _set_nodes $net_path $2 $1
+    _set_nodes $net_path $1 $2 $3
     _set_users $net_path $4
     _set_vars $net_path $1 $2 $3 $4
 
@@ -318,7 +320,7 @@ users=${users:-5}
 # Main
 #######################################
 
-# Validate.
+# Execute when inputs are valid.
 if [ $bootstraps -ge $nodes ]; then
     log_error "Invalid input: boostraps MUST BE < nodes"
 else

--- a/sh/assets/setup_supervisord.sh
+++ b/sh/assets/setup_supervisord.sh
@@ -6,8 +6,8 @@
 #   NCTL - path to nctl home directory.
 # Arguments:
 #   Path to network directory.
+#   Network ordinal identifer.
 #   Nodeset count.
-#   Network ordinal identifier.
 #######################################
 
 # Set supervisord.conf file.
@@ -33,11 +33,11 @@ serverurl=unix:///$1/daemon/socket/supervisord.sock ;
 EOM
 
     # Set supervisord.conf app sections.
-for node_id in $(seq 1 $2)
+for node_id in $(seq 1 $3)
 do
     cat >> $1/daemon/config/supervisord.conf <<- EOM
 
-[program:casper-net-$3-node-$node_id]
+[program:casper-net-$2-node-$node_id]
 autostart=false
 autorestart=false
 command=$1/bin/casper-node validator $1/nodes/node-$node_id/config/node-config.toml ;

--- a/sh/daemon/supervisord/daemon_kill.sh
+++ b/sh/daemon/supervisord/daemon_kill.sh
@@ -14,6 +14,5 @@ source $NCTL/sh/daemon/supervisord/utils.sh
 # If sock file exists then stop daemon.
 if [ -e "$(get_path_net_supervisord_sock $1)" ]; then
     supervisorctl -c "$(get_path_net_supervisord_cfg $1)" stop all &>/dev/null
-    supervisorctl -c "$(get_path_net_supervisord_cfg $1)" status &>/dev/null
     supervisorctl -c "$(get_path_net_supervisord_cfg $1)" shutdown &>/dev/null
 fi

--- a/sh/daemon/supervisord/node_status.sh
+++ b/sh/daemon/supervisord/node_status.sh
@@ -15,4 +15,5 @@ source $NCTL/sh/daemon/supervisord/utils.sh
 source $NCTL/sh/daemon/supervisord/daemon_start.sh $1
 
 # Display nodeset state.
+log "supervisord node process states:"
 supervisorctl -c "$(get_path_net_supervisord_cfg $1)" status all

--- a/sh/node/start.sh
+++ b/sh/node/start.sh
@@ -63,9 +63,13 @@ if [ $node = "all" ]; then
         else
             log "network #$net: starting node $node_idx"
         fi
+
+        # Use daemon specific script to start node.
         if [ $NCTL_DAEMON_TYPE = "supervisord" ]; then
             source $NCTL/sh/daemon/supervisord/node_start.sh $net $node_idx
         fi
+
+        # When boostraps have been started then await before proceeeding to start non-boostrap nodes.
         if [ $node_idx -eq $NCTL_NET_BOOTSTRAP_COUNT ]; then
             sleep 2.0
             log "network #$net: starting ... "

--- a/sh/node/stop.sh
+++ b/sh/node/stop.sh
@@ -37,6 +37,8 @@ node=${node:-all}
 # Main
 #######################################
 
+log "network #$net: stopping node(s) ... please wait"
+
 if [ $NCTL_DAEMON_TYPE = "supervisord" ]; then
     source $NCTL/sh/daemon/supervisord/node_stop.sh $net $node
 fi

--- a/sh/utils/misc.sh
+++ b/sh/utils/misc.sh
@@ -29,6 +29,31 @@ function log ()
     fi
 }
 
+# Wraps standard echo by adding application prefix.
+function log_error ()
+{
+    # Set timestamp.
+    declare now=`date +%Y-%m-%dT%H:%M:%S:000000`
+
+    # Support tabs.
+    declare tabs=''
+
+    # Emit log message.
+    if [ "$1" ]; then
+        if [ "$2" ]; then
+            for ((i=0; i<$2; i++))
+            do
+                declare tabs+='\t'
+            done
+            echo $now" [ERROR] [$$] NCTL :: "$tabs$1
+        else
+            echo $now" [ERROR] [$$] NCTL :: "$1
+        fi
+    else
+        echo $now" [ERROR] [$$] NCTL :: "
+    fi
+}
+
 # Wraps pushd command to suppress stdout.
 function pushd ()
 {


### PR DESCRIPTION
The nctl-assets-setup now accepts a `bootstraps` parameter, i.e. the number of nodes in the network being instantiated that are to be considered as bootstraps.  

This results in the network.known_addresses config setting for **non-bootstrap** nodes being assigned to the network addresses of the bootstrap nodes.